### PR TITLE
fix:調整評論功能預設三則限制，修正評論無法滑動問題

### DIFF
--- a/src/components/Events/EventComments.vue
+++ b/src/components/Events/EventComments.vue
@@ -97,8 +97,6 @@ const myComments = computed(() => {
           {{ c.createdAt }}
         </div>
       </div>
-
-      <!-- 如果不足 3 則補空卡，維持 2x2 視覺 -->
     </div>
   </div>
 </template>


### PR DESCRIPTION
1.原本評論功能新增後會把舊的評論刪除，因為寫死了評論數量最多三個。
A:調整後評論不會再被吃掉。

2.評論頁本來被鎖定住導致沒辦法滑動。
A:修正後無論電腦版或是手機版都可以滑動了。
