### PR TITLE
style: 重新設定主題色並定義使用範圍

### DIFF
--- a/src/styles/token.css
+++ b/src/styles/token.css
@@ -101,19 +101,19 @@
     'Helvetica Neue', Arial;
 
   /* Background */
-  --color-bg-base: #fcfaf2; /* 米：頁面底色 */
+  --color-bg-base: #fffdf8; /* 米：頁面底色 */
   --color-bg-surface: #ffffff; /* 白：卡片/內容表面 */
 
   /* Brand */
-  --color-brand-primary: #2e6256; /* 綠：主品牌（主按鈕/選中/自己訊息） */
-  --color-brand-accent: #edc920; /* 黃：強調（badge/小CTA） */
-  --color-mayekawa: #2a594f; /* 首頁綠色 */
+  --color-brand-primary: #ffa75f; /* 橘：主品牌（主按鈕/選中/自己訊息） */
+  --color-brand-secondary: #ffd19d; /* 首頁跑馬燈 */
+  --color-brand-tertiary: #ffd9ad; /* 淺橘：登入頁背景 */
+  --color-brand-accent: #ff655d; /* 淡紅：強調（badge/小CTA） */
   --color-func-danger: #ff4d4f; /* 紅：危險/錯誤/收藏 */
   --color-status-success: #16a34a; /* 綠：成功狀態文字 */
-
   --color-status-warning: #ff9f43; /* 橘：警告/進行中狀態 */
 
-  /* Foreground (text/border source) */
+  /* Foreground */
   --color-fg-primary: #382710; /* 深棕：主要文字 */
   --color-fg-secondary: #5c4b3d; /* 棕：次要文字 */
   --color-fg-muted: #8b7d73; /* 淺棕：輔助文字 */
@@ -123,11 +123,11 @@
   --color-link-hover: #3f7fbf; /* 藍：連結文字懸停 */
 
   /* Button */
-  --color-btn-primary: #edc920; /* 黃：主要按鈕背景 */
-  --color-btn-secondary: #2e6256; /* 綠：次要按鈕背景 */
+  --color-btn-primary: #ff953f; /* 橘：主要按鈕背景 */
+  --color-btn-secondary: #ffffff; /* 白：次要按鈕背景 */
   --color-btn-accent: #949494; /* 灰：輔助按鈕背景 */
 
-  /* Border (recommended: use softened fg) */
+  /* Border */
   --color-border-default: rgba(56, 39, 16, 0.18);
   --color-border-strong: rgba(56, 39, 16, 0.28);
 
@@ -145,9 +145,9 @@
 }
 
 /* 全站預設，讓大家不用每個地方都重複寫 */
-@layer base {  
+@layer base {
   :root {
-  --header-h: var(--header-height-mobile);
+    --header-h: var(--header-height-mobile);
   }
   @media (min-width: 768px) {
     :root {


### PR DESCRIPTION
針對背景色、品牌色、狀態色與按鈕色系進行重新對齊，確保色調與wireframe一致性。

**調整內容：**
- 更新頁面底色 `--color-bg-base` 
- 調整品牌主色與輔助品牌色( primary / secondary / tertiary )
- 統一按鈕主色 ( `--color-btn-primary` ) 與次要按鈕 ( -`-color-btn-secondary` ) 色彩語意
- 移除或合併與設計稿不一致的舊有色票
<img width="1551" height="744" alt="image" src="https://github.com/user-attachments/assets/48af20f7-a6ea-4fa0-bcb5-57b2da7fc3d5" />

@Louis-369 此次更改有造成以下影響，後續調整再麻煩注意囉~
1. 移除`--color-mayekawa: #2a594f; /* 首頁綠色 */` ，
重新定義為`--color-brand-secondary: #ffd19d; /* 首頁跑馬燈 */`
會導致跑馬燈及覆蓋選單背景色消失，可以於 [issue/84](https://github.com/pet-human-pet/PetPetNi/issues/84)一併調整
2. 首頁之背景色也記得修改 `MainFrame.vue` 第16行 之 `bg-[#EBE7D9]`
3. 有定義登入頁面色票，後續可以把背景色硬編碼修改為`bg-brand-tertiary`