### PR TITLE
feat: 第三方登入實作

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "package",
       "version": "0.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.91.0",
         "@tailwindcss/vite": "^4.1.18",
         "@vueuse/core": "^14.1.0",
         "axios": "^1.13.2",
@@ -2980,6 +2981,86 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.91.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.91.0.tgz",
+      "integrity": "sha512-9ywvsKLsxTwv7fvN5fXzP3UfRreqrX2waylTBDu0lkmeHXa8WtSQS9e0WV9FBduiazYqQbgfBQXBNPRPsRgWOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.91.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.91.0.tgz",
+      "integrity": "sha512-WaakXOqLK1mLtBNFXp5o5T+LlI6KZuADSeXz+9ofPRG5OpVSvW148LVJB1DRZ16Phck1a0YqIUswOUgxCz6vMw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.91.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.91.0.tgz",
+      "integrity": "sha512-5S41zv2euNpGucvtM4Wy+xOmLznqt/XO+Lh823LOFEQ00ov7QJfvqb6VzIxufvzhooZpmGR0BxvMcJtWxCIFdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.91.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.91.0.tgz",
+      "integrity": "sha512-u2YuJFG35umw8DO9beC27L/jYXm3KhF+73WQwbynMpV0tXsFIA0DOGRM0NgRyy03hJIdO6mxTTwe8efW3yx3Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.91.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.91.0.tgz",
+      "integrity": "sha512-CI7fsVIBQHfNObqU9kmyQ1GWr+Ug44y4rSpvxT4LdQB9tlhg1NTBov6z7Dlmt8d6lGi/8a9lf/epCDxyWI792g==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.91.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.91.0.tgz",
+      "integrity": "sha512-Rjb0QqkKrmXMVwUOdEqysPBZ0ZDZakeptTkUa6k2d8r3strBdbWVDqjOdkCjAmvvZMtXecBeyTyMEXD1Zzjfvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.91.0",
+        "@supabase/functions-js": "2.91.0",
+        "@supabase/postgrest-js": "2.91.0",
+        "@supabase/realtime-js": "2.91.0",
+        "@supabase/storage-js": "2.91.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -3291,6 +3372,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
+      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -3310,6 +3406,15 @@
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
       "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.50.0",
@@ -6070,6 +6175,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -8959,6 +9073,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -9096,6 +9216,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.91.0",
     "@tailwindcss/vite": "^4.1.18",
     "@vueuse/core": "^14.1.0",
     "axios": "^1.13.2",
     "browser-image-compression": "^2.0.2",
-    "dayjs": "^1.11.19",
     "chart.js": "^4.5.1",
+    "dayjs": "^1.11.19",
     "pinia": "^3.0.4",
     "socket.io-client": "^4.8.3",
     "tailwindcss": "^4.1.18",

--- a/src/components/Onboarding/OwnerInfo.vue
+++ b/src/components/Onboarding/OwnerInfo.vue
@@ -11,6 +11,10 @@ const props = defineProps({
   initialData: {
     type: Object,
     default: null
+  },
+  showEmail: {
+    type: Boolean,
+    default: true
   }
 })
 
@@ -98,6 +102,7 @@ const handleSubmit = () => {
 
   // 提交資料
   emit('submit', {
+    email: props.email, // 使用 props 中的 email（一般註冊或 OAuth 都有）
     realName: realName.value,
     nickname: nickname.value,
     phone: cleanPhone,
@@ -123,7 +128,7 @@ const handleSubmit = () => {
       @submit.prevent="handleSubmit"
     >
       <!-- Email（唯讀顯示） -->
-      <div class="space-y-2">
+      <div v-if="showEmail" class="space-y-2">
         <label class="text-sm font-medium text-gray-600">Email</label>
         <div class="w-full rounded-xl border-2 border-gray-200 bg-gray-50 px-4 py-3 text-gray-500">
           {{ email }}

--- a/src/components/login/LoginForm.vue
+++ b/src/components/login/LoginForm.vue
@@ -3,6 +3,23 @@ import { ref, watch } from 'vue'
 import BaseInput from '@/components/Form/BaseInput.vue'
 import { useAuthStore } from '@/stores/auth'
 import { useRouter } from 'vue-router'
+import { supabase } from '@/lib/supabase'
+
+const signInWithGoogle = async () => {
+  const { error } = await supabase.auth.signInWithOAuth({ provider: 'google' })
+  if (error) {
+    console.error('登入錯誤', error)
+    alert('登入失敗：' + error.message)
+  }
+}
+
+const loginWithGithub = async () => {
+  const { error } = await supabase.auth.signInWithOAuth({ provider: 'github' })
+  if (error) {
+    console.error('GitHub 登入錯誤', error)
+    alert('GitHub 登入失敗：' + error.message)
+  }
+}
 
 const authStore = useAuthStore()
 const router = useRouter()
@@ -77,10 +94,16 @@ const handleLogin = async () => {
 
   // 呼叫登入 API
   try {
-    await authStore.login(email.value, password.value)
+    const result = await authStore.login(email.value, password.value)
 
-    // 登入成功，導向首頁
-    router.push('/')
+    // 檢查是否需要完成註冊流程
+    if (result.needsRegistration) {
+      // 導向角色選擇頁面
+      router.push({ name: 'login', query: { mode: 'role' } })
+    } else {
+      // 登入成功，導向首頁
+      router.push('/')
+    }
   } catch (error) {
     // 顯示錯誤訊息
     if (error.response?.data?.error) {
@@ -101,15 +124,15 @@ const handleLogin = async () => {
 
     <!-- 第三方登入按鈕 -->
     <div class="mb-8 grid grid-cols-2 gap-4">
-      <!-- Discord 登入 -->
+      <!-- github 登入 -->
       <button
         type="button"
         class="flex items-center justify-center rounded-xl border-2 border-gray-300 px-4 py-3 transition-all duration-200 hover:border-gray-400 hover:bg-gray-50 focus:ring-2 focus:ring-gray-400 focus:outline-none"
-        @click="handleSocialLogin('discord')"
+        @click="loginWithGithub"
       >
-        <svg class="h-5 w-5 text-[#5865F2]" fill="currentColor" viewBox="0 0 24 24">
+        <svg class="h-5 w-5" viewBox="0 0 98 96">
           <path
-            d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026 13.83 13.83 0 0 0 1.226-1.963.074.074 0 0 0-.041-.104 13.201 13.201 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028zM8.02 15.278c-1.182 0-2.157-1.069-2.157-2.38 0-1.312.956-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.956 2.38-2.157 2.38zm7.975 0c-1.183 0-2.157-1.069-2.157-2.38 0-1.312.955-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.946 2.38-2.157 2.38z"
+            d="M41.4395 69.3848C28.8066 67.8535 19.9062 58.7617 19.9062 46.9902C19.9062 42.2051 21.6289 37.0371 24.5 33.5918C23.2559 30.4336 23.4473 23.7344 24.8828 20.959C28.7109 20.4805 33.8789 22.4902 36.9414 25.2656C40.5781 24.1172 44.4062 23.543 49.0957 23.543C53.7852 23.543 57.6133 24.1172 61.0586 25.1699C64.0254 22.4902 69.2891 20.4805 73.1172 20.959C74.457 23.543 74.6484 30.2422 73.4043 33.4961C76.4668 37.1328 78.0937 42.0137 78.0937 46.9902C78.0937 58.7617 69.1934 67.6621 56.3691 69.2891C59.623 71.3945 61.8242 75.9883 61.8242 81.252V91.2051C61.8242 94.0762 64.2168 95.7031 67.0879 94.5547C84.4102 87.9512 98 70.6289 98 49.1914C98 22.1074 75.9883 0 48.9043 0C21.8203 0 0 22.1074 0 49.1914C0 70.4375 13.4941 88.0469 31.6777 94.6504C34.2617 95.6074 36.75 93.8848 36.75 91.3008V83.6445C35.4102 84.2188 33.6875 84.6016 32.1562 84.6016C25.8398 84.6016 22.1074 81.1563 19.4277 74.7441C18.375 72.1602 17.2266 70.6289 15.0254 70.3418C13.877 70.2461 13.4941 69.7676 13.4941 69.1934C13.4941 68.0449 15.4082 67.1836 17.3223 67.1836C20.0977 67.1836 22.4902 68.9063 24.9785 72.4473C26.8926 75.2227 28.9023 76.4668 31.2949 76.4668C33.6875 76.4668 35.2187 75.6055 37.4199 73.4043C39.0469 71.7773 40.291 70.3418 41.4395 69.3848Z"
           />
         </svg>
       </button>
@@ -118,7 +141,7 @@ const handleLogin = async () => {
       <button
         type="button"
         class="flex items-center justify-center rounded-xl border-2 border-gray-300 px-4 py-3 transition-all duration-200 hover:border-gray-400 hover:bg-gray-50 focus:ring-2 focus:ring-gray-400 focus:outline-none"
-        @click="handleSocialLogin('google')"
+        @click="signInWithGoogle"
       >
         <svg class="h-5 w-5" viewBox="0 0 24 24">
           <path

--- a/src/components/login/RegisterForm.vue
+++ b/src/components/login/RegisterForm.vue
@@ -3,6 +3,7 @@ import { ref, watch } from 'vue'
 import BaseInput from '@/components/Form/BaseInput.vue'
 import { usePasswordValidator, isASCIIPassword } from '@/composables/usePasswordValidator'
 import { useAuthStore } from '@/stores/auth'
+import { supabase } from '@/lib/supabase'
 
 const authStore = useAuthStore()
 
@@ -34,6 +35,22 @@ watch(confirmPassword, () => {
 
 const togglePassword = () => {
   showPassword.value = !showPassword.value
+}
+
+const signInWithGoogle = async () => {
+  const { error } = await supabase.auth.signInWithOAuth({ provider: 'google' })
+  if (error) {
+    console.error('登入錯誤', error)
+    alert('登入失敗：' + error.message)
+  }
+}
+
+const loginWithGithub = async () => {
+  const { error } = await supabase.auth.signInWithOAuth({ provider: 'github' })
+  if (error) {
+    console.error('GitHub 登入錯誤', error)
+    alert('GitHub 登入失敗：' + error.message)
+  }
 }
 
 // TODO: 串接後端 API - 獲取 OAuth 授權 URL
@@ -122,15 +139,15 @@ const handleRegister = async () => {
 
     <!-- 第三方登入按鈕 -->
     <div class="mb-8 grid grid-cols-2 gap-4">
-      <!-- Discord 登入 -->
+      <!-- GitHub 登入 -->
       <button
         type="button"
-        class="flex items-center justify-center rounded-xl border-2 border-gray-300 px-4 py-3 transition-all duration-200 hover:border-gray-400 hover:bg-gray-50 focus:ring-2 focus:ring-gray-400 focus:outline-none"
-        @click="handleSocialLogin('discord')"
+        class="flex items-center justify-center rounded-xl border-2 border-gray-300 transition-all duration-200 hover:border-gray-400 hover:bg-gray-50 focus:ring-2 focus:ring-gray-400 focus:outline-none"
+        @click="loginWithGithub"
       >
-        <svg class="h-5 w-5 text-[#5865F2]" fill="currentColor" viewBox="0 0 24 24">
+        <svg class="h-5 w-5" viewBox="0 0 98 96">
           <path
-            d="M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026 13.83 13.83 0 0 0 1.226-1.963.074.074 0 0 0-.041-.104 13.201 13.201 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028zM8.02 15.278c-1.182 0-2.157-1.069-2.157-2.38 0-1.312.956-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.956 2.38-2.157 2.38zm7.975 0c-1.183 0-2.157-1.069-2.157-2.38 0-1.312.955-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.946 2.38-2.157 2.38z"
+            d="M41.4395 69.3848C28.8066 67.8535 19.9062 58.7617 19.9062 46.9902C19.9062 42.2051 21.6289 37.0371 24.5 33.5918C23.2559 30.4336 23.4473 23.7344 24.8828 20.959C28.7109 20.4805 33.8789 22.4902 36.9414 25.2656C40.5781 24.1172 44.4062 23.543 49.0957 23.543C53.7852 23.543 57.6133 24.1172 61.0586 25.1699C64.0254 22.4902 69.2891 20.4805 73.1172 20.959C74.457 23.543 74.6484 30.2422 73.4043 33.4961C76.4668 37.1328 78.0937 42.0137 78.0937 46.9902C78.0937 58.7617 69.1934 67.6621 56.3691 69.2891C59.623 71.3945 61.8242 75.9883 61.8242 81.252V91.2051C61.8242 94.0762 64.2168 95.7031 67.0879 94.5547C84.4102 87.9512 98 70.6289 98 49.1914C98 22.1074 75.9883 0 48.9043 0C21.8203 0 0 22.1074 0 49.1914C0 70.4375 13.4941 88.0469 31.6777 94.6504C34.2617 95.6074 36.75 93.8848 36.75 91.3008V83.6445C35.4102 84.2188 33.6875 84.6016 32.1562 84.6016C25.8398 84.6016 22.1074 81.1563 19.4277 74.7441C18.375 72.1602 17.2266 70.6289 15.0254 70.3418C13.877 70.2461 13.4941 69.7676 13.4941 69.1934C13.4941 68.0449 15.4082 67.1836 17.3223 67.1836C20.0977 67.1836 22.4902 68.9063 24.9785 72.4473C26.8926 75.2227 28.9023 76.4668 31.2949 76.4668C33.6875 76.4668 35.2187 75.6055 37.4199 73.4043C39.0469 71.7773 40.291 70.3418 41.4395 69.3848Z"
           />
         </svg>
       </button>
@@ -139,7 +156,7 @@ const handleRegister = async () => {
       <button
         type="button"
         class="flex items-center justify-center rounded-xl border-2 border-gray-300 px-4 py-3 transition-all duration-200 hover:border-gray-400 hover:bg-gray-50 focus:ring-2 focus:ring-gray-400 focus:outline-none"
-        @click="handleSocialLogin('google')"
+        @click="signInWithGoogle"
       >
         <svg class="h-5 w-5" viewBox="0 0 24 24">
           <path

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import './style.css'
+import { supabase } from '@/lib/supabase'
 
 const app = createApp(App)
 
@@ -13,5 +14,17 @@ app.use(router)
 import { useAuthStore } from './stores/auth'
 const authStore = useAuthStore()
 authStore.initAuth()
+
+// 初始化 Supabase Auth 監聽
+supabase.auth.onAuthStateChange(async (event, session) => {
+  console.log('[Supabase Auth]', event, session)
+
+  if (event === 'SIGNED_IN' && session) {
+    // OAuth 登入成功，處理 session
+    await authStore.handleSupabaseSession(session)
+  } else if (event === 'SIGNED_OUT') {
+    console.log('✅ Supabase 登出')
+  }
+})
 
 app.mount('#app')

--- a/src/views/Login/AuthView.vue
+++ b/src/views/Login/AuthView.vue
@@ -19,6 +19,7 @@ const router = useRouter()
 const authMode = ref('login')
 const userRole = ref('owner') // 用於成功頁面顯示不同訊息
 const userEmail = ref('') // 儲存用戶 Email
+const isOAuthLogin = ref(false) // 追蹤是否為第三方登入
 const countdown = ref(3)
 let countdownTimer = null
 
@@ -33,6 +34,17 @@ onMounted(() => {
     authMode.value = 'register'
   } else if (route.query.mode === 'social_bind') {
     authMode.value = 'social_bind'
+    isOAuthLogin.value = true // 標記為 OAuth 登入
+  } else if (route.query.mode === 'role') {
+    authMode.value = 'role'
+    // 檢查是否從 OAuth 登入來的（如果有 session 但沒有 profile）
+    import('@/stores/auth').then(({ useAuthStore }) => {
+      const authStore = useAuthStore()
+      if (authStore.user && authStore.user.email) {
+        userEmail.value = authStore.user.email
+        isOAuthLogin.value = true
+      }
+    })
   }
 })
 
@@ -263,6 +275,7 @@ onUnmounted(() => {
             <OwnerInfo
               :email="userEmail"
               :initial-data="ownerData"
+              :show-email="!isOAuthLogin"
               @submit="handleOwnerInfoSubmit"
               @back="handleGoBack"
             />


### PR DESCRIPTION
# feat: 整合 Supabase OAuth (Google/GitHub) 登入流程與 Profile 檢查


## 1. 資料變動 (Data Changes)

主要在前端建立了完整的「第三方登入」與「用戶資料完整性檢查」機制，並非單純修改資料庫欄位，而是改變了**狀態管理**與**路由邏輯**。

### 核心變動檔案
*   **[src/stores/auth.js](file:///Users/louis/Desktop/team-project/PetPetNi/src/stores/auth.js) (Auth Store)**
    *   **新增狀態**: `userIdInt` , `isLoading`, `error`.
    *   **新增邏輯**: `handleSupabaseSession(session)` 用於處理 OAuth 回傳的 Session。
    *   **新增檢查**: `checkProfileExists(userId)`，登入後會立即查詢 Supabase `profiles` table，確認該 User ID 是否已有建立個人檔案。
*   **[src/views/Login/AuthCallback.vue](file:///Users/louis/Desktop/team-project/PetPetNi/src/views/Login/AuthCallback.vue) (新增檔案)**
    *   作為 OAuth (Google/GitHub) 登入後的「回調頁面 (Callback URL)」。負責接收 URL 中的 code 並交換成 Session，然後觸發 Store 的處理邏輯。
*   **[src/components/login/LoginForm.vue](file:///Users/louis/Desktop/team-project/PetPetNi/src/components/login/LoginForm.vue)**
    *   新增 Google 與 GitHub 登入按鈕。
    *   一般登入 (`login`) 後，新增了判斷 `needsRegistration` 的邏輯。
*   **[src/views/Login/AuthView.vue](file:///Users/louis/Desktop/team-project/PetPetNi/src/views/Login/AuthView.vue)**
    *   作為登入流程的「狀態機 (State Machine)」，根據 `authMode` 切換顯示 `LoginForm`、`RegisterForm` 或 `RoleSelection` (角色選擇)。

---

## 2. 目的 (Purpose)

此 Commit 的主要目的是**強制執行「註冊引導 (Onboarding)」流程**，確保系統中的每個使用者都有完整的 Profile 資料。

1.  **整合 Social Login**: 讓使用者可以用 Google/GitHub 快速登入（此時只在 `auth.users` 表有資料）。
2.  **資料完整性防護**: 防止使用者只完成了 Auth 驗證（有帳號），卻沒有應用層的 Profile（沒有角色、暱稱、寵物資料）就進入首頁。
3.  **分流機制**: 
    *   **老手 (有 Profile)** -> 直接進首頁。
    *   **新手 (無 Profile)** -> 強制導向「角色選擇」->「填寫飼主資料」->「填寫寵物資料」。

---

## 3. 資料流轉 (Data Flow)

下圖展示了此 Commit 建立的登入與資料檢查流程：

```mermaid
flowchart TD
    User((使用者))
    
    subgraph Frontend ["前端應用 (Vue)"]
        LoginPage["登入頁面 (LoginForm)"]
        AuthCallback["OAuth 回調頁 (AuthCallback)"]
        AuthStore["狀態管理 (AuthStore)"]
        RolePage["角色選擇/註冊引導"]
        HomePage["首頁 (Home)"]
    end

    subgraph Backend ["Supabase"]
        AuthService["Auth Service"]
        DB[("資料庫 (Profiles)")]
    end

    %% 流程開始
    User --> |1. 點擊 Google/GitHub| LoginPage
    User --> |1. 輸入帳密| LoginPage

    %% 登入路徑 A: Social
    LoginPage --> |2a. OAuth Redirect| AuthService
    AuthService --> |3a. Callback with Code| AuthCallback
    AuthCallback --> |4a. Exchange Session| AuthStore

    %% 登入路徑 B: Email
    LoginPage -.-> |2b. API Login| AuthService
    AuthService -.-> |3b. Return User/Session| LoginPage
    LoginPage -.-> |4b. Call Login Action| AuthStore

    %% 核心檢查邏輯
    AuthStore --> |5. checkProfileExists| DB
    DB -- 回傳 Profile 資料? --> AuthStore

    %% 分流決策
    AuthStore -- "❌ 無資料 (Null)" --> Decision{需註冊?}
    AuthStore -- "✅ 有資料 (Found)" --> HomePage

    Decision --> |User 無 Profile| RolePage
    RolePage --> |6. 填寫資料 & 建立 Profile| DB
    DB --> |7. 建立成功| HomePage

    style AuthStore fill:#f9f,stroke:#333,stroke-width:2px
    style DB fill:#bbf,stroke:#333,stroke-width:2px
    style Decision fill:#ff9,stroke:#333,stroke-width:2px
```

### 流程詳解
1.  **觸發**: 使用者發起登入 (Social 或 Email)。
2.  **驗證**: 取得 Supabase 的 `session` 與 `user` 物件 (代表身分驗證成功)。
3.  **檢查 (關鍵步驟)**:
    *   前端 `AuthStore` 拿 `user.id` 去查詢 `profiles` table。
    *   **若查詢失敗或無資料**: 判定為「新用戶」或「資料不全」。
    *   **若查詢成功**: 判定為「有效用戶」。
4.  **轉導**:
    *   **有效用戶**: 更新 Store 狀態 (`user_id_int`) 並導向首頁。
    *   **新用戶**: 導向 `/login?mode=role`，強制進入註冊流程，直到 Profile 建立完成。
