### PR TITLE
fix: 修正字體載入路徑，確保 Zeabur 部署後正確套用 GenSenRounded

### DIFF
--- a/public/fonts/GenSenRounded2TC-B.woff2
+++ b/public/fonts/GenSenRounded2TC-B.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:692bb1b02b887a0c227fc6b48a3f7f68b36b23c091734f25cad3774ae4fd0f4a
+size 7959348

--- a/public/fonts/GenSenRounded2TC-EL.woff2
+++ b/public/fonts/GenSenRounded2TC-EL.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ff692a7f2abc31fa748795432c8b51e10f396d741b8413331ab7f62af7fe5da
+size 6321392

--- a/public/fonts/GenSenRounded2TC-H.woff2
+++ b/public/fonts/GenSenRounded2TC-H.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7854a4f6e6593b44c7d427a6872967c23c13ad148d899b8f97c6ee0acb1ad8a6
+size 7880388

--- a/public/fonts/GenSenRounded2TC-L.woff2
+++ b/public/fonts/GenSenRounded2TC-L.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08e4c428a1c30e9431533003d1b87b5a6bc779b7b8ac649bf2c51a69069360fe
+size 7154640

--- a/public/fonts/GenSenRounded2TC-M.woff2
+++ b/public/fonts/GenSenRounded2TC-M.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d0bcb9d53efa74f19e9c76b9dbdb8da1b660ef4936f06fa8072d6c6a73daa07
+size 7761976

--- a/public/fonts/GenSenRounded2TC-R.woff2
+++ b/public/fonts/GenSenRounded2TC-R.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ad8a7fa1b4744ca7e76fc1bb842d7aa3d866168c7e63e18af48f3605bd23b42
+size 7553512

--- a/public/fonts/GenSenRounded2TW-B.woff2
+++ b/public/fonts/GenSenRounded2TW-B.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2b1d36ba38a40dcd5930d3a9d170577461d82c7aab5bbbb0afbf1110b1409df
+size 6619740

--- a/public/fonts/GenSenRounded2TW-EL.woff2
+++ b/public/fonts/GenSenRounded2TW-EL.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4c465c78f48e936bbbec5b5ab7fc54b12fe2ea39b06371052bf00c32ca59bca
+size 5315452

--- a/public/fonts/GenSenRounded2TW-H.woff2
+++ b/public/fonts/GenSenRounded2TW-H.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12071fb3dc222f0d3122047ee40acad7e66a622b02fd675de1a9d91744b3b5a9
+size 6619140

--- a/public/fonts/GenSenRounded2TW-L.woff2
+++ b/public/fonts/GenSenRounded2TW-L.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fc37c68231e2061db2b84960a73fcfb29003970d07d0f4ef78a5883cce5e024
+size 6053204

--- a/public/fonts/GenSenRounded2TW-M.woff2
+++ b/public/fonts/GenSenRounded2TW-M.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32a8f52eabcbc0933c5178c0b68f6af79356c00cc9f5240be66532ec18e7d426
+size 6429288

--- a/public/fonts/GenSenRounded2TW-R.woff2
+++ b/public/fonts/GenSenRounded2TW-R.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d2c9d9a0d8bfd06779a623815800278061916b7c847bcc175dd22e05a4e00ce
+size 6275732

--- a/src/styles/token.css
+++ b/src/styles/token.css
@@ -1,6 +1,6 @@
 @font-face {
   font-family: 'GenSenRounded';
-  src: url('../assets/fonts/GenSenRounded2TW-EL.woff2') format('woff2');
+  src: url('/fonts/GenSenRounded2TW-EL.woff2') format('woff2');
   font-weight: 200;
   font-style: normal;
   font-display: swap;
@@ -8,7 +8,7 @@
 
 @font-face {
   font-family: 'GenSenRounded';
-  src: url('../assets/fonts/GenSenRounded2TC-EL.woff2') format('woff2');
+  src: url('/fonts/GenSenRounded2TC-EL.woff2') format('woff2');
   font-weight: 200;
   font-style: normal;
   font-display: swap;
@@ -16,7 +16,7 @@
 
 @font-face {
   font-family: 'GenSenRounded';
-  src: url('../assets/fonts/GenSenRounded2TW-L.woff2') format('woff2');
+  src: url('/fonts/GenSenRounded2TW-L.woff2') format('woff2');
   font-weight: 300;
   font-style: normal;
   font-display: swap;
@@ -24,7 +24,7 @@
 
 @font-face {
   font-family: 'GenSenRounded';
-  src: url('../assets/fonts/GenSenRounded2TC-L.woff2') format('woff2');
+  src: url('/fonts/GenSenRounded2TC-L.woff2') format('woff2');
   font-weight: 300;
   font-style: normal;
   font-display: swap;
@@ -32,7 +32,7 @@
 
 @font-face {
   font-family: 'GenSenRounded';
-  src: url('../assets/fonts/GenSenRounded2TW-R.woff2') format('woff2');
+  src: url('/fonts/GenSenRounded2TW-R.woff2') format('woff2');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -40,7 +40,7 @@
 
 @font-face {
   font-family: 'GenSenRounded';
-  src: url('../assets/fonts/GenSenRounded2TC-R.woff2') format('woff2');
+  src: url('/fonts/GenSenRounded2TC-R.woff2') format('woff2');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -48,7 +48,7 @@
 
 @font-face {
   font-family: 'GenSenRounded';
-  src: url('../assets/fonts/GenSenRounded2TW-M.woff2') format('woff2');
+  src: url('/fonts/GenSenRounded2TW-M.woff2') format('woff2');
   font-weight: 500;
   font-style: normal;
   font-display: swap;
@@ -56,7 +56,7 @@
 
 @font-face {
   font-family: 'GenSenRounded';
-  src: url('../assets/fonts/GenSenRounded2TC-M.woff2') format('woff2');
+  src: url('/fonts/GenSenRounded2TC-M.woff2') format('woff2');
   font-weight: 500;
   font-style: normal;
   font-display: swap;
@@ -64,7 +64,7 @@
 
 @font-face {
   font-family: 'GenSenRounded';
-  src: url('../assets/fonts/GenSenRounded2TW-B.woff2') format('woff2');
+  src: url('/fonts/GenSenRounded2TW-B.woff2') format('woff2');
   font-weight: 700;
   font-style: normal;
   font-display: swap;
@@ -72,7 +72,7 @@
 
 @font-face {
   font-family: 'GenSenRounded';
-  src: url('../assets/fonts/GenSenRounded2TC-B.woff2') format('woff2');
+  src: url('/fonts/GenSenRounded2TC-B.woff2') format('woff2');
   font-weight: 700;
   font-style: normal;
   font-display: swap;
@@ -80,7 +80,7 @@
 
 @font-face {
   font-family: 'GenSenRounded';
-  src: url('../assets/fonts/GenSenRounded2TW-H.woff2') format('woff2');
+  src: url('/fonts/GenSenRounded2TW-H.woff2') format('woff2');
   font-weight: 900;
   font-style: normal;
   font-display: swap;
@@ -88,7 +88,7 @@
 
 @font-face {
   font-family: 'GenSenRounded';
-  src: url('../assets/fonts/GenSenRounded2TC-H.woff2') format('woff2');
+  src: url('/fonts/GenSenRounded2TC-H.woff2') format('woff2');
   font-weight: 900;
   font-style: normal;
   font-display: swap;


### PR DESCRIPTION
因為先前字體放在 src/public/fonts，CSS 使用 /fonts/...（根路徑）去找
實際上 Vite 只會從專案根目錄的 public/ 提供靜態資源，導致本機與部署都抓不到字體

本次修正將字體移到正確的 public/fonts，讓 /fonts/... 正常解析並成功套用字體。

### 調整內容：
- 將 GenSenRounded 字體檔由 src/assets/fonts 移至 public/fonts
- 統一使用絕對路徑 (/fonts/...) 定義 @font-face

修正後：
- Rendered Fonts 正確顯示為 GenSenRounded
- dev / production 環境行為一致

### 測試方式：
1. 於任一文字右鍵->檢查，進到開發者工具後打開computed滑到最下面
2. 確認 Rendered Fonts 為 GenSenRounded

https://github.com/user-attachments/assets/6249eff9-9c3d-430c-ab6e-93d95b6f35d4

### 注意事項
這種寫法只在「網站部署在網域根目錄」時正常（例如 https://your-app.zeabur.app/）
若未來改成「子路徑部署」（例如 https://your-domain.com/petpetni/），/fonts/... 會 404
需要改 vite.config.js 的 base 設為 /petpetni/
或將字體路徑改成相對路徑。